### PR TITLE
Updating FastTravelWaypoints for mcMMO 1.4.00

### DIFF
--- a/src/ben657/fasttravelwaypoints/FastTravelWaypoints.java
+++ b/src/ben657/fasttravelwaypoints/FastTravelWaypoints.java
@@ -4,16 +4,14 @@
  */
 package ben657.fasttravelwaypoints;
 
-import bsh.EvalError;
-import bsh.Interpreter;
-import com.gmail.nossr50.mcMMO;
-import com.gmail.nossr50.api.ExperienceAPI;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
+
 import net.milkbowl.vault.economy.Economy;
 import net.milkbowl.vault.economy.EconomyResponse;
+
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.command.Command;
@@ -25,6 +23,12 @@ import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionDefault;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
+
+import bsh.EvalError;
+import bsh.Interpreter;
+
+import com.gmail.nossr50.mcMMO;
+import com.gmail.nossr50.api.ExperienceAPI;
 
 /**
  *

--- a/src/ben657/fasttravelwaypoints/Waypoint.java
+++ b/src/ben657/fasttravelwaypoints/Waypoint.java
@@ -6,6 +6,7 @@ package ben657.fasttravelwaypoints;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import org.bukkit.Location;
 
 /**


### PR DESCRIPTION
Because this plugin was using mcMMO internals instead of the API it broke with mcMMO 1.4.00
