### PR TITLE
Replace deprecated usage of `Server.getOnlinePlayers()`

### DIFF
--- a/src/ben657/fasttravelwaypoints/FastTravelWaypoints.java
+++ b/src/ben657/fasttravelwaypoints/FastTravelWaypoints.java
@@ -82,9 +82,7 @@ public class FastTravelWaypoints extends JavaPlugin {
         BukkitRunnable foundCheck = new BukkitRunnable() {
             @Override
             public void run() {
-                Player[] players = getServer().getOnlinePlayers();
-                for (int p = 0; p < players.length; p++) {
-                    Player player = players[p];
+                for (Player player : getServer().getOnlinePlayers()) {
                     for (int i = 0; i < waypoints.size(); i++) {
                         Waypoint point = waypoints.get(i);
                         if (player.getLocation().getWorld().getName() != point.loc.getWorld().getName()) {


### PR DESCRIPTION
The return value changed in Bukkit 1.7 onwards, however implementations still supported the old return value through hacks. Spigot 1.9 onwards removes the support for the deprecated version of `Server.getOnlinePlayers()`.

This uses the non-deprecated version of `Server.getOnlinePlayers()` to correctly use the one that returns `Collection<? extends Player>` instead of `Player[]`.
